### PR TITLE
use 'IA' instead of 'Ia'

### DIFF
--- a/swcalculator-server/src/main/java/gov/epa/stormwater/service/CalculateServiceImpl.java
+++ b/swcalculator-server/src/main/java/gov/epa/stormwater/service/CalculateServiceImpl.java
@@ -799,7 +799,7 @@ public class CalculateServiceImpl implements CalculateService {
                     case "I":
                         rSeries = fillRainTimeSeries(siteData.getXEventModel().getRainfall()[i], siteData.getXEventModel().getScsI());  //rainfall[i], scsI, ref rSeries); 
                         break;
-                    case "Ia":
+                    case "IA":
                         rSeries = fillRainTimeSeries(siteData.getXEventModel().getRainfall()[i], siteData.getXEventModel().getScsIa());  //fillRainTimeSeries(rainfall[i], scsIa, ref rSeries); 
                         break;
                     case "II":


### PR DESCRIPTION
Close #13.

In the file PREC_SCS_Types.txt, the `Rainfall_Distribution_Type` is given as `IA`, not `Ia`.  Fixing this prevents the crash when locations in the Pacific Northwest/northern California are used.